### PR TITLE
chore: enable static export

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  output: 'export',
+};
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- configure Next.js to export static site via `output: 'export'`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891ac0594648328a5f50331b4e84dee